### PR TITLE
Updated

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,65 +2,66 @@
 name = "clog"
 version = "0.2.0"
 dependencies = [
- "docopt 0.6.39 (registry+https://github.com/rust-lang/crates.io-index)",
- "docopt_macros 0.6.39 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex_macros 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-serialize 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "time 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "docopt 0.6.55 (registry+https://github.com/rust-lang/crates.io-index)",
+ "docopt_macros 0.6.55 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 0.1.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex_macros 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.3.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "docopt"
-version = "0.6.39"
+version = "0.6.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "regex 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-serialize 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 0.1.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.3.10 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "docopt_macros"
-version = "0.6.39"
+version = "0.6.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "docopt 0.6.39 (registry+https://github.com/rust-lang/crates.io-index)",
+ "docopt 0.6.55 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "gcc"
-version = "0.1.7"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "libc"
-version = "0.1.2"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "regex"
-version = "0.1.15"
+version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "regex_macros"
-version = "0.1.8"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "regex 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 0.1.24 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "rustc-serialize"
-version = "0.2.15"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "time"
-version = "0.1.17"
+version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "gcc 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gcc 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,7 +2,7 @@
 name = "clog"
 version = "0.2.0"
 dependencies = [
- "clap 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clap 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.1.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex_macros 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -10,7 +10,7 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "0.5.5"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,7 +2,7 @@
 name = "clog"
 version = "0.2.0"
 dependencies = [
- "clap 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clap 0.5.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.1.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex_macros 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -10,7 +10,7 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "0.5.6"
+version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,30 +2,18 @@
 name = "clog"
 version = "0.2.0"
 dependencies = [
- "docopt 0.6.55 (registry+https://github.com/rust-lang/crates.io-index)",
- "docopt_macros 0.6.55 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clap 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.1.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex_macros 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-serialize 0.3.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
-name = "docopt"
-version = "0.6.55"
+name = "clap"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 0.1.24 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-serialize 0.3.10 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "docopt_macros"
-version = "0.6.55"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "docopt 0.6.55 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -50,11 +38,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "regex 0.1.24 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
-
-[[package]]
-name = "rustc-serialize"
-version = "0.3.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "time"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,9 +5,7 @@ version = "0.2.0"
 authors = ["Christoph Burgdorf <christoph.burgdorf@bvsn.org>"]
 
 [dependencies]
-docopt = "*"
-docopt_macros = "*"
 regex = "*"
 regex_macros = "*"
 time = "*"
-rustc-serialize = "*"
+clap = "*"

--- a/src/format_util.rs
+++ b/src/format_util.rs
@@ -1,4 +1,4 @@
 
 pub fn get_short_hash(hash: &str) -> &str {
-    hash.slice_chars(0,8)
+    &hash[0..8]
 }

--- a/src/git.rs
+++ b/src/git.rs
@@ -14,19 +14,14 @@ pub struct LogReaderConfig {
 }
 
 pub fn get_latest_tag () -> String {
-    let mut buf = String::new();
-    Command::new("git")
+    let output = Command::new("git")
             .arg("rev-list")
             .arg("--tags")
             .arg("--max-count=1")
-            .spawn()
-            .ok().expect("failed to invoke ref-list")
-            .stdout.as_mut().unwrap().read_to_string(&mut buf)
-            .ok().expect("failed to get latest git log");
+            .output().unwrap_or_else(|e| panic!("Failed to run git rev-list with error: {}",e));
+    let buf = String::from_utf8_lossy(&output.stdout);
 
-            buf
-            .trim_matches('\n')
-            .to_owned()
+    buf.trim_matches('\n').to_owned()
 }
 
 pub fn get_last_commit () -> String {

--- a/src/log_writer.rs
+++ b/src/log_writer.rs
@@ -3,23 +3,24 @@ use std::io::{Write, Result};
 use time;
 use format_util;
 use common::{ LogEntry };
+use std::borrow::ToOwned;
 
-pub struct LogWriter<'a> {
-    writer: &'a mut (Writer + 'a),
-    options: LogWriterOptions
+pub struct LogWriter<'a, 'lwo> {
+    writer: &'a mut (Write + 'a),
+    options: LogWriterOptions<'lwo>
 }
 
-pub struct LogWriterOptions {
-    pub repository_link: String,
+pub struct LogWriterOptions<'a> {
+    pub repository_link: &'a str,
     pub version: String,
-    pub subtitle: String
+    pub subtitle: String 
 }
 
-impl<'a> LogWriter<'a> {
+impl<'a, 'lwo> LogWriter<'a, 'lwo> {
 
-    fn commit_link(&self, hash: &String) -> String {
-        let short_hash = format_util::get_short_hash(hash.as_slice());
-        match self.options.repository_link.as_slice() {
+    fn commit_link(hash: &String, options: &LogWriterOptions) -> String {
+        let short_hash = format_util::get_short_hash(&hash[..]);
+        match &options.repository_link[..] {
             "" => format!("({})", short_hash),
             link => format!("[{}]({}/commit/{})", short_hash, link, hash)
 
@@ -27,7 +28,7 @@ impl<'a> LogWriter<'a> {
     }
 
     fn issue_link(&self, issue: &String) -> String {
-        match self.options.repository_link.as_slice() {
+        match &self.options.repository_link[..] {
             "" => format!("(#{})", issue),
             link => format!("[#{}]({}/issues/{})", issue, link, issue)
         }
@@ -35,22 +36,25 @@ impl<'a> LogWriter<'a> {
 
     pub fn write_header(&mut self) -> Result<()> {
         let subtitle = match self.options.subtitle.len() {
-            0 => self.options.subtitle.clone(),
+            0 => self.options.subtitle.to_owned(),
             _ => format!(" {}", self.options.subtitle)
         };
 
         let version_text = format!("## {}{}", self.options.version, subtitle);
 
-        let date = time::now_utc().strftime("%Y-%m-%d");
+        let date = time::now_utc();
 
-        write!(self.writer, "<a name=\"{}\"></a>\n{} ({})\n\n", self.options.version, version_text, date)
+        match date.strftime("%Y-%m-%d") {
+            Ok(date) => write!(self.writer, "<a name=\"{}\"></a>\n{} ({})\n\n", self.options.version, version_text, date),
+            Err(_)   => write!(self.writer, "<a name=\"{}\"></a>\n{} ({})\n\n", self.options.version, version_text, "XXXX-XX-XX")
+        }
     }
 
     pub fn write_section(&mut self, title: &str, section: &HashMap<String, Vec<LogEntry>>)
                             -> Result<()> {
         if section.len() == 0 { return Ok(()) }
 
-        try!(self.writer.write_line(format!("\n#### {}\n\n", title).as_slice()));
+        try!(self.writer.write(&format!("\n#### {}\n\n", title)[..].as_bytes()));
 
         for (component, entries) in section.iter() {
             let nested = entries.len() > 1;
@@ -58,7 +62,7 @@ impl<'a> LogWriter<'a> {
             //TODO: implement the empty component stuff
             let prefix = if nested {
                 try!(write!(self.writer, "* **{}**\n", component));
-                "  *".to_string()
+                "  *".to_owned()
             } else {
                 format!("* **{}**", component)
             };
@@ -67,7 +71,7 @@ impl<'a> LogWriter<'a> {
                 try!(write!(self.writer, "{} {} ({}",
                                          prefix,
                                          entry.subject,
-                                         self.commit_link(&entry.hash)));
+                                         LogWriter::commit_link(&entry.hash, &self.options)));
 
                 if entry.closes.len() > 0 {
                     let closes_string = entry.closes.iter()
@@ -93,7 +97,8 @@ impl<'a> LogWriter<'a> {
         write!(self.writer, "{}", content)
     }
 
-    pub fn new<T:Writer + Send>(writer: &'a mut T, options: LogWriterOptions) -> LogWriter<'a> {
+    pub fn new<T>(writer: &'a mut T, options: LogWriterOptions<'lwo>) -> LogWriter<'a, 'lwo>
+        where T: Write + Send {
         LogWriter {
             writer: writer,
             options: options

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,10 +4,10 @@
 #![plugin(docopt_macros)]
 #![plugin(regex_macros)]
 
-extern crate "rustc-serialize" as rustc_serialize;
 extern crate regex;
 extern crate regex_macros;
 extern crate serialize;
+extern crate "rustc-serialize" as rustc_serialize;
 extern crate docopt_macros;
 extern crate docopt;
 extern crate time;

--- a/src/main.rs
+++ b/src/main.rs
@@ -66,7 +66,6 @@ fn main () {
 
     let start_nsec = time::get_time().nsec;
 
-    ;
     let log_reader_config = LogReaderConfig {
         grep: "^feat|^fix|BREAKING'".to_owned(),
         format: "%H%n%s%n%b%n==END==".to_owned(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,20 +1,20 @@
 #![crate_name = "clog"]
-#![feature(macro_rules)]
 #![feature(plugin)]
-#![plugin(docopt_macros)]
 #![plugin(regex_macros)]
 
 extern crate regex;
-extern crate regex_macros;
-extern crate serialize;
-extern crate "rustc-serialize" as rustc_serialize;
-extern crate docopt_macros;
-extern crate docopt;
 extern crate time;
+
+extern crate clap;
 
 use git::LogReaderConfig;
 use log_writer::{ LogWriter, LogWriterOptions };
 use std::fs::File;
+use std::io::Read;
+use std::path::Path;
+use std::borrow::ToOwned;
+
+use clap::{App, Arg};
 
 mod common;
 mod git;
@@ -22,57 +22,83 @@ mod log_writer;
 mod section_builder;
 mod format_util;
 
-docopt!(Args, "clog
-
-Usage:
-  clog [--repository=<link> --setversion=<version> --subtitle=<subtitle>]
-       [--from=<from> --to=<to> --from-latest-tag]
-
-Options:
-  -h --help               Show this screen.
-  --version               Show version
-  -r --repository=<link>  e.g https://github.com/thoughtram/clog
-  --setversion=<version>  e.g. 0.1.0
-  --subtitle=<subtitle>   e.g. crazy-release-name
-  --from=<from>           e.g. 12a8546
-  --to=<to>               e.g. 8057684
-  --from-latest-tag       uses the latest tag as starting point. Ignores other --from parameter",
-  flag_from: Option<String>,
-  flag_setversion: Option<String>);
 
 fn main () {
+    // Pull version from Cargo.toml
+    let version = format!("{}.{}.{}{}",
+                          env!("CARGO_PKG_VERSION_MAJOR"),
+                          env!("CARGO_PKG_VERSION_MINOR"),
+                          env!("CARGO_PKG_VERSION_PATCH"),
+                          option_env!("CARGO_PKG_VERSION_PRE").unwrap_or(""));
+    let matches = App::new("clog")
+        .version(&version[..])
+        .about("a conventional changelog for the rest of us")
+        .arg(Arg::new("repository")
+            .short("r")
+            .long("repository")
+            .takes_value(true)
+            .required(true)
+            .help("e.g. https://github.com/thoughtram/clog"))
+        .arg(Arg::new("setversion")
+            .long("setversion")
+            .help("e.g. 1.0.1")
+            .takes_value(true))
+        .arg(Arg::new("subtitle")
+            .long("subtitle")
+            .help("e.g. crazy-release-title")
+            .takes_value(true)
+            .required(true))
+        .arg(Arg::new("from")
+            .help("e.g. 12a8546")
+            .long("from")
+            .required(true)
+            .takes_value(true))
+        .arg(Arg::new("to")
+            .long("to")
+            .help("e.g. 8057684")
+            .takes_value(true)
+            .required(true))
+        .arg(Arg::new("from-latest-tag")
+            .long("from-latest-tag")
+            .help("uses the latest tag as starting point (ignores other --from parameters)")
+            .mutually_excludes("from"))
+        .get_matches();
 
     let start_nsec = time::get_time().nsec;
-    let args: Args = Args::docopt().decode().unwrap_or_else(|e| e.exit());
 
+    ;
     let log_reader_config = LogReaderConfig {
-        grep: "^feat|^fix|BREAKING'".to_string(),
-        format: "%H%n%s%n%b%n==END==".to_string(),
-        from: if args.flag_from_latest_tag { Some(git::get_latest_tag()) } else { args.flag_from },
-        to: args.flag_to
+        grep: "^feat|^fix|BREAKING'".to_owned(),
+        format: "%H%n%s%n%b%n==END==".to_owned(),
+        from: if matches.is_present("from-latest-tag") { Some(git::get_latest_tag()) } else { Some(matches.value_of("from").unwrap().to_owned()) },
+        to: matches.value_of("to").unwrap().to_owned()
     };
 
     let commits = git::get_log_entries(log_reader_config);
 
     let sections = section_builder::build_sections(commits.clone());
 
-    let contents = match File::open(&Path::new("changelog.md")).read_to_string() {
-      Ok(content) => content,
-      Err(_)      => "".to_string()
-    };
+    let mut contents = String::new();
+    match File::open(&Path::new("changelog.md")).ok().expect("couldn't open changelog.md").read_to_string(&mut contents) {
+        Ok(_) => (),
+        Err(_) => contents = "".to_owned()
+    }
 
     let mut file = File::create(&Path::new("changelog.md")).ok().unwrap();
     let mut writer = LogWriter::new(&mut file, LogWriterOptions {
-        repository_link: args.flag_repository,
-        version: args.flag_setversion
-                     .unwrap_or_else(|| format_util::get_short_hash(git::get_last_commit().as_slice()).to_string()),
-        subtitle: args.flag_subtitle
+        repository_link: matches.value_of("repository").unwrap(),
+        version: if matches.is_present("setversion") {
+                    matches.value_of("setversion").unwrap().to_owned()
+                } else {
+                    format_util::get_short_hash(&git::get_last_commit()[..]).to_owned()
+                },
+        subtitle: matches.value_of("subtitle").unwrap().to_owned()
     });
 
     writer.write_header().ok().expect("failed to write header");
     writer.write_section("Bug Fixes", &sections.fixes).ok().expect("failed to write bugfixes");;
     writer.write_section("Features", &sections.features).ok().expect("failed to write features");;
-    writer.write(contents.as_slice()).ok().expect("failed to write contents");;
+    writer.write(&contents[..]).ok().expect("failed to write contents");;
 
     let end_nsec = time::get_time().nsec;
     let elapsed_mssec = (end_nsec - start_nsec) / 1000000;

--- a/src/section_builder.rs
+++ b/src/section_builder.rs
@@ -14,7 +14,7 @@ pub fn build_sections(log_entries: Vec<LogEntry>) -> SectionMap {
         match entry.commit_type {
             Feature => {
                 let feature = match sections.features.entry(entry.component.clone()) {
-                    Vacant(v) => v.set(Vec::new()),
+                    Vacant(v) => v.insert(Vec::new()),
                     Occupied(o) => o.into_mut()
                 };
 
@@ -27,7 +27,7 @@ pub fn build_sections(log_entries: Vec<LogEntry>) -> SectionMap {
             },
             Fix => {
                 let fix = match sections.fixes.entry(entry.component.clone()) {
-                    Vacant(v) => v.set(Vec::new()),
+                    Vacant(v) => v.insert(Vec::new()),
                     Occupied(o) => o.into_mut()
                 };
 


### PR DESCRIPTION
@thoughtram @vyp @cburgdorf 

I've updated `clog` and it's now compiling and working. I was having issues with `docopt` compiling so I switched to `clap` also I'm more familiar with `clap` since I maintain it. You still get the help/version/usage info for free  (just run `clog --help` for info). You can switch back to `docopt` once it's updated without much effort.

I ran it on this fork and it took 7ms to run...since I don't have any prior knowledge I'm not sure if that's a `+` or `-`

Hope this works for you! :)