### PR TITLE
refactor(clog): update to beta compatible version of Rust

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,49 +2,37 @@
 name = "clog"
 version = "0.3.1"
 dependencies = [
- "clap 0.5.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 0.1.24 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex_macros 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "time 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clap 0.5.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.24 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "clap"
-version = "0.5.7"
+version = "0.5.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "libc 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
 [[package]]
 name = "gcc"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "libc"
-version = "0.1.4"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "regex"
-version = "0.1.24"
+version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "regex_macros"
-version = "0.1.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "regex 0.1.24 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
 [[package]]
 name = "time"
-version = "0.1.22"
+version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "gcc 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gcc 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,5 @@ description = "A conventional changelog for the rest of us"
 
 [dependencies]
 regex = "*"
-regex_macros = "*"
 time = "*"
 clap = "*"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,4 @@
 #![crate_name = "clog"]
-#![feature(plugin)]
-#![plugin(regex_macros)]
 
 extern crate regex;
 extern crate time;
@@ -16,12 +14,16 @@ use std::borrow::ToOwned;
 
 use clap::{App, Arg};
 
+// regex cheat thanks to https://github.com/BurntSushi
+macro_rules! regex(
+    ($s:expr) => (::regex::Regex::new($s).unwrap());
+);
+
 mod common;
 mod git;
 mod log_writer;
 mod section_builder;
 mod format_util;
-
 
 fn main () {
     // Pull version from Cargo.toml


### PR DESCRIPTION
Allows compiling with stable Rust 1.0 beta channel (i.e. nightly not required)