### PR TITLE
Implements #34 (and a bug fix)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,7 +2,7 @@
 name = "clog"
 version = "0.5.0"
 dependencies = [
- "clap 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clap 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.1.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex_macros 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "semver 0.1.19 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -12,7 +12,7 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "0.7.5"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A [conventional](https://github.com/ajoslin/conventional-changelog/blob/master/C
 
 ```
 USAGE:
-    clog [FLAGS] [OPTIONS]
+	clog [FLAGS] [OPTIONS]
 
 FLAGS:
         --from-latest-tag    use latest tag as start (instead of --from)
@@ -22,12 +22,12 @@ FLAGS:
     -v, --version            Prints version information
 
 OPTIONS:
-        --from=from                   e.g. 12a8546
-    -r, --repository <repository>     e.g. https://github.com/thoughtram/clog
-        --setversion <setversion>     e.g. 1.0.1
-        --subtitle <subtitle>         e.g. crazy-release-title
-        --to <to>                     e.g. 8057684 (Defaults to HEAD when omitted)
-
+        --from <from>                e.g. 12a8546
+    -o, --outfile <outfile>          Where to write the changelog (Defaults to 'changelog.md')
+    -r, --repository <repository>    e.g. https://github.com/thoughtram/clog
+        --subtitle <subtitle>        e.g. crazy-release-title
+        --to <to>                    e.g. 8057684 (Defaults to HEAD when omitted)
+        --setversion <ver>           e.g. 1.0.1
 ```
 
 ### Try it!
@@ -38,17 +38,22 @@ OPTIONS:
 
 3. Delete the old changelog file `rm changelog.md`
 
-3. Run clog `./target/release/clog -r https://github.com/thoughtram/clog --setversion 0.1.0 --subtitle crazy-dog --from 88ccacd`
+3. Run clog `./target/release/clog -r https://github.com/thoughtram/clog --setversion 0.1.0 --subtitle crazy-dog --from 6d8183f`
 
 ### Default Options
 
-`clog` can also be configured using a default configuration file so that you don't have to specify all the options each time you want to update your changelog. To do this add a `.clog.toml` file to your repository. 
+`clog` can also be configured using a default configuration file so that you don't have to specify all the options each time you want to update your changelog. To do this add a `.clog.toml` file to your repository.
 
 ```toml
 [clog]
 repository = "https://github.com/thoughtram/clog"
 subtitle = "my awesome title"
-# If you use tags, you can set the following
+
+# sets the changelog output file, defaults to "changelog.md" if omitted
+outfile = "MyChangelog.md"
+
+# If you use tags, you can set the following if you wish to only pick
+# up changes since your latest tag
 from-latest-tag = true
 ```
 
@@ -66,6 +71,8 @@ MySection = ["mysec", "ms"]
 ```
 
 Now if you make a commit message such as `mysec(Component): some message` or `ms(Component): some message` there will be a new "MySection" section along side the "Features" and "Bug Fixes" areas.
+
+*NOTE:* Sections with spaces are suppported, such as `"My Special Section" = ["ms", "mysec"]`
 
 ## LICENSE
 

--- a/src/clogconfig.rs
+++ b/src/clogconfig.rs
@@ -20,13 +20,14 @@ pub struct ClogConfig {
     pub subtitle: String,
     pub from: String,
     pub to: String,
+    pub changelog: String,
     pub section_map: HashMap<String, Vec<String>>
 }
 
 pub type ConfigResult = Result<ClogConfig, Box<Display>>;
 
 impl ClogConfig {
-    pub fn from_matches(matches: &ArgMatches) -> ConfigResult { 
+    pub fn from_matches(matches: &ArgMatches) -> ConfigResult {
         // compute version early, so we can exit on error
         let version =  {
             // less typing later...
@@ -39,7 +40,7 @@ impl ClogConfig {
                 let first_char = v_string.chars().nth(0).unwrap_or(' ');
                 let v_slice = if first_char == 'v' || first_char == 'V' {
                     had_v = true;
-                    v_string.trim_left_matches(|c| c == 'v' || c == 'V')   
+                    v_string.trim_left_matches(|c| c == 'v' || c == 'V')
                 } else {
                     &v_string[..]
                 };
@@ -58,7 +59,7 @@ impl ClogConfig {
                         return Err(Box::new(format!("Error: {}\n\n\tEnsure the tag format follows Semantic Versioning such as N.N.N\n\tor set the version manually with --setversion <version>" , e )));
                     }
                 }
-            } else {           
+            } else {
                 // Use short hash
                 (&git::get_last_commit()[0..8]).to_owned()
             }
@@ -79,6 +80,8 @@ impl ClogConfig {
         let mut toml_from_latest = None;
         let mut toml_repo = None;
         let mut toml_subtitle = None;
+
+        let mut outfile = None;
 
         if let Ok(ref mut toml_f) = File::open(cfg_file){
             let mut toml_s = String::with_capacity(100);
@@ -114,6 +117,14 @@ impl ClogConfig {
                 Some(val) => Some(val.as_str().unwrap_or("").to_owned()),
                 None      => Some("".to_owned())
             };
+<<<<<<< HEAD
+            changelog = match clog_table.lookup("changelog") {
+=======
+            changelog = match clog_table.lookup("outfile") {
+>>>>>>> da3e9b0... fixup! feat(changelog.md): allows specifying custom file for changelog
+                Some(val) => Some(val.as_str().unwrap_or("changelog.md").to_owned()),
+                None      => None
+            };
             match toml_table.get("sections") {
                 Some(table) => {
                     match table.as_table() {
@@ -133,11 +144,11 @@ impl ClogConfig {
         };
 
         let from = if matches.is_present("from-latest-tag") || toml_from_latest.unwrap_or(false) {
-            git::get_latest_tag() 
-        } else if let Some(from) = matches.value_of("from") { 
+            git::get_latest_tag()
+        } else if let Some(from) = matches.value_of("from") {
             from.to_owned()
         } else {
-           "".to_owned() 
+           "".to_owned()
         };
 
         let repo = match matches.value_of("repository") {
@@ -150,15 +161,18 @@ impl ClogConfig {
             None        => toml_subtitle.unwrap_or("".to_owned())
         };
 
+        if let Some(file) = matches.value_of("outfile") {
+            outfile = Some(file.to_owned());
+        }
 
         Ok(ClogConfig{
-            grep: format!("{}BREAKING'", 
+            grep: format!("{}BREAKING'",
                 sections.values()
                         .map(|v| v.iter().fold(String::new(), |acc, al| {
                             acc + &format!("^{}|", al)[..]
                         }))
                         .fold(String::new(), |acc, al| {
-                            acc + &format!("^{}|", al)[..] 
+                            acc + &format!("^{}|", al)[..]
                         })),
             format: "%H%n%s%n%b%n==END==".to_owned(),
             repo: repo,
@@ -166,6 +180,7 @@ impl ClogConfig {
             subtitle: subtitle,
             from: from,
             to: matches.value_of("to").unwrap_or("HEAD").to_owned(),
+            changelog: outfile.unwrap_or("changelog.md".to_owned()),
             section_map: sections
         })
     }

--- a/src/clogconfig.rs
+++ b/src/clogconfig.rs
@@ -117,11 +117,7 @@ impl ClogConfig {
                 Some(val) => Some(val.as_str().unwrap_or("").to_owned()),
                 None      => Some("".to_owned())
             };
-<<<<<<< HEAD
-            changelog = match clog_table.lookup("changelog") {
-=======
-            changelog = match clog_table.lookup("outfile") {
->>>>>>> da3e9b0... fixup! feat(changelog.md): allows specifying custom file for changelog
+            outfile = match clog_table.lookup("outfile") {
                 Some(val) => Some(val.as_str().unwrap_or("changelog.md").to_owned()),
                 None      => None
             };

--- a/src/clogconfig.rs
+++ b/src/clogconfig.rs
@@ -143,10 +143,10 @@ impl ClogConfig {
             };
         };
 
-        let from = if matches.is_present("from-latest-tag") || toml_from_latest.unwrap_or(false) {
-            git::get_latest_tag()
-        } else if let Some(from) = matches.value_of("from") {
+        let from = if let Some(from) = matches.value_of("from") {
             from.to_owned()
+        } else if matches.is_present("from-latest-tag") || toml_from_latest.unwrap_or(false) {
+            git::get_latest_tag()
         } else {
            "".to_owned()
         };

--- a/src/main.rs
+++ b/src/main.rs
@@ -44,6 +44,7 @@ fn main () {
                           --patch                       'Increment patch version by one'
                           --subtitle=[subtitle]         'e.g. crazy-release-title'
                           --to=[to]                     'e.g. 8057684 (Defaults to HEAD when omitted)'
+                          -o --outfile=[outfile]        'Where to write the changelog (Defaults to \'changelog.md\')'
                           --setversion=[ver]            'e.g. 1.0.1'")
         // Because --from-latest-tag can't be used with --from, we add it seperately so we can
         // specify a .mutually_excludes()
@@ -58,16 +59,16 @@ fn main () {
     let start_nsec = time::get_time().nsec;
 
     let clog_config = ClogConfig::from_matches(&matches).unwrap_or_else(|e| { println!("{}",e); std::process::exit(1); });
-    
+
     let commits = git::get_log_entries(&clog_config);
 
     let sm = SectionMap::from_entries(commits);
 
     let mut contents = String::new();
 
-    File::open(&Path::new("changelog.md")).map(|mut f| f.read_to_string(&mut contents).ok()).ok();
+    File::open(&Path::new(&clog_config.changelog[..])).map(|mut f| f.read_to_string(&mut contents).ok()).ok();
 
-    let mut file = File::create(&Path::new("changelog.md")).ok().unwrap();
+    let mut file = File::create(&Path::new(&clog_config.changelog[..])).ok().unwrap();
     let mut writer = LogWriter::new(&mut file, &clog_config);
 
     writer.write_header().ok().expect("failed to write header");


### PR DESCRIPTION
This PR adds a `-o <file>` and `--outfile <file>` as well as a `outfile = "myfile.md"` to the `.clog.toml`