### PR TITLE
chore(*): update deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,7 +2,7 @@
 name = "clog"
 version = "0.6.0"
 dependencies = [
- "clap 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clap 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.1.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex_macros 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "semver 0.1.19 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -11,9 +11,18 @@ dependencies = [
 ]
 
 [[package]]
-name = "clap"
-version = "0.7.6"
+name = "ansi_term"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "clap"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "ansi_term 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "strsim 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "gcc"
@@ -22,7 +31,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "libc"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -49,12 +58,17 @@ version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "strsim"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "time"
 version = "0.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "gcc 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -7,6 +7,12 @@ clog
 
 A [conventional](https://github.com/ajoslin/conventional-changelog/blob/master/CONVENTIONS.md) changelog for the rest of us
 
+### About
+
+`clog` creates a changelog automatically from your local git metadata. See the `clog`s [changelog.md](https://github.com/thoughtram/clog/blob/master/changelog.md) for an example.
+
+The way this works, is every time you make a commit, you ensure your commit subject line follows the [conventional](https://github.com/thoughtram/clog/blob/master/changelog.md) format. Then when you wish to update your changelog, you simply run `clog` inside your local repository with any options you'd like to specify.
+
 ### Usage
 
 ```
@@ -57,13 +63,13 @@ outfile = "MyChangelog.md"
 from-latest-tag = true
 ```
 
-Now you can update your `changelog.md` with `clog --patch` (assuming you want to update from the latest tag version, and increment your patch version by 1).
+Now you can update your `MyChangelog.md` with `clog --patch` (assuming you want to update from the latest tag version, and increment your patch version by 1).
 
 *Note:* Any options you specify at the command line will override options set in your `.clog.toml`
 
 #### Custom Sections
 
-When using a `.clog.toml` file you can add your own custom sections to show up in your `changelog.md`. Add a `[sections]` table, along with the sections and aliases you'd like to use:
+By default, `clog` will display two sections in your changelog, `Features` and `Bug Fixes`. You can add additional sections by using a `.clog.toml` file. To add more sections, simply add a `[sections]` table, along with the section name and aliases you'd like to use in your commit messages:
 
 ```toml
 [sections]


### PR DESCRIPTION
This is just a dep update. One to note is there have been some big improvements (no breaking changes) to `clap`. Notably, suggestions are now made when a user makes a typo.

For example, run `$ clog --majr` (missing the `o`) and you'll see:

```sh
$ clog --majr
The argument --majr isn't valid
	Did you mean --major ?

USAGE:
	clog --major

For more information try --help
```

The same for all the arguments (except single character ones). This could really help new users. 

One other visible change is errors (such as the one above) are printed in red text. If @cburgdorf  doesn't want the text colored we can disable that feature and still get everything else via this in the `Cargo.toml`:

```toml
[dependencies.clap]
version = "*"
default-features = false

# i.e. removing the "color" feature but keeping the "suggestions" feature
features = ["suggestions"]
```
