### PR TITLE
fix: fixes a typo in the command line config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,6 @@ USAGE:
     clog [FLAGS] [OPTIONS]
 
 FLAGS:
-    -c, --config             The Clog Configuration TOML file to use (Defaults to '.clog.toml')**
     -F, --from-latest-tag    use latest tag as start (instead of --from)
     -h, --help               Prints help information
     -M, --major              Increment major version by one (Sets minor and patch to 0)
@@ -38,6 +37,7 @@ FLAGS:
     -V, --version            Prints version information
 
 OPTIONS:
+    -c, --config <config>            The Clog Configuration TOML file to use (Defaults to '.clog.toml')**
     -f, --from <from>                e.g. 12a8546
     -g, --git-dir <gitdir>           Local .git directory (defaults to current dir + '.git')*
     -o, --outfile <outfile>          Where to write the changelog (Defaults to 'changelog.md')

--- a/src/bin/clog.rs
+++ b/src/bin/clog.rs
@@ -28,7 +28,7 @@ fn main () {
                           -s, --subtitle=[subtitle] 'e.g. \"Crazy Release Title\"'
                           -t, --to=[to]             'e.g. 8057684 (Defaults to HEAD when omitted)'
                           -o, --outfile=[outfile]   'Where to write the changelog (Defaults to \'changelog.md\')'
-                          -c, --config              'The Clog Configuration TOML file to use (Defaults to \'.clog.toml\')**'
+                          -c, --config=[config]     'The Clog Configuration TOML file to use (Defaults to \'.clog.toml\')**'
                           --setversion=[ver]        'e.g. 1.0.1'")
         // Because --from-latest-tag can't be used with --from, we add it seperately so we can
         // specify a .conflicts_with()


### PR DESCRIPTION
Just tested, and it's working as expected now. Since this is a super minimal change, and really just the result of a typo, I'll merge once Travis passes.